### PR TITLE
Fix adding whatsapp participant

### DIFF
--- a/app/src/main/res/layout/view_add_non_chat_participant_screen.xml
+++ b/app/src/main/res/layout/view_add_non_chat_participant_screen.xml
@@ -30,7 +30,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/hint_add_non_chat_participant_phone"
-                android:inputType="phone"
+                android:inputType="textNoSuggestions"
                 android:imeOptions="actionDone"/>
 
         </com.google.android.material.textfield.TextInputLayout>
@@ -50,7 +50,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/hint_add_non_chat_participant_proxy"
-                android:inputType="phone"
+                android:inputType="textNoSuggestions"
                 android:imeOptions="actionDone"/>
 
         </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
While adding whatsapp participant we should use phone
and proxy numbers like `whatsapp:+12312345678`

So we should allow input letters into phone and proxy fields


