### PR TITLE
Fix message updated event handling

### DIFF
--- a/app/src/main/java/com/twilio/conversations/app/data/localCache/dao/MessagesDao.kt
+++ b/app/src/main/java/com/twilio/conversations/app/data/localCache/dao/MessagesDao.kt
@@ -20,7 +20,11 @@ interface MessagesDao {
     @Query("SELECT * FROM message_table WHERE conversationSid = :conversationSid ORDER BY CASE WHEN `index` < 0 THEN dateCreated ELSE `index` END DESC LIMIT 1")
     fun getLastMessage(conversationSid: String): MessageDataItem?
 
-    // Get single Message
+    // Get single Message by SID
+    @Query("SELECT * FROM message_table WHERE sid = :sid")
+    fun getMessageBySid(sid: String): MessageDataItem?
+
+    // Get single Message by UUID
     @Query("SELECT * FROM message_table WHERE uuid = :uuid")
     fun getMessageByUuid(uuid: String): MessageDataItem?
 

--- a/app/src/main/java/com/twilio/conversations/app/repository/ConversationsRepository.kt
+++ b/app/src/main/java/com/twilio/conversations/app/repository/ConversationsRepository.kt
@@ -5,7 +5,6 @@ import com.twilio.conversations.*
 import com.twilio.conversations.Participant.Type.CHAT
 import com.twilio.conversations.app.common.*
 import com.twilio.conversations.app.common.enums.CrashIn
-import com.twilio.conversations.app.common.enums.DownloadState
 import com.twilio.conversations.app.common.extensions.*
 import com.twilio.conversations.app.data.ConversationsClientWrapper
 import com.twilio.conversations.app.data.localCache.LocalCacheProvider
@@ -436,8 +435,9 @@ class ConversationsRepositoryImpl(
     private fun updateMessage(message: Message, updateReason: Message.UpdateReason? = null) {
         launch {
             val identity = conversationsClientWrapper.getConversationsClient().myIdentity
+            val uuid = localCache.messagesDao().getMessageBySid(message.sid)?.uuid ?: ""
             Timber.d("Message updated: ${message.toMessageDataItem(identity)}, reason: $updateReason")
-            localCache.messagesDao().insertOrReplace(message.toMessageDataItem(identity))
+            localCache.messagesDao().insertOrReplace(message.toMessageDataItem(identity, uuid))
             updateConversationLastMessage(message.conversationSid)
         }
     }


### PR DESCRIPTION
Since we introduced combined primary key for MessageDataItem,
we have to pass non-empty uuid when updating message. Otherwise the same
message will be duplicated n repository with two different primary keys:
(SID, "") and (SID, UUID)

